### PR TITLE
feat(docker): add disk usage analysis and cleanup step to Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -42,6 +42,70 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Analyze disk usage and cleanup
+        run: |
+          echo "=== Initial disk usage ==="
+          df -h
+          echo ""
+          echo "=== Checking what large directories exist ==="
+          
+          # Check each directory and show size if it exists
+          for dir in "/usr/share/dotnet" "/usr/local/lib/android" "/opt/ghc" "/opt/hostedtoolcache/CodeQL" "/opt/hostedtoolcache" "/usr/share/swift" "/usr/local/share/boost"; do
+            if [ -d "$dir" ]; then
+              size=$(sudo du -sh "$dir" 2>/dev/null | cut -f1)
+              echo "Found: $dir ($size)"
+            else
+              echo "Not found: $dir"
+            fi
+          done
+          
+          echo ""
+          echo "=== Docker usage ==="
+          docker system df || true
+          
+          echo ""
+          echo "=== Top 10 largest directories in /opt ==="
+          sudo du -h /opt 2>/dev/null | sort -hr | head -10 || true
+          
+          echo ""
+          echo "=== Top 10 largest directories in /usr/share ==="
+          sudo du -h /usr/share 2>/dev/null | sort -hr | head -10 || true
+          
+          echo ""
+          echo "=== Starting cleanup of confirmed large directories ==="
+          
+          # Only remove directories that exist and are large
+          if [ -d "/usr/share/dotnet" ]; then
+            echo "Removing .NET SDK..."
+            sudo rm -rf /usr/share/dotnet
+          fi
+          
+          if [ -d "/usr/local/lib/android" ]; then
+            echo "Removing Android SDK..."
+            sudo rm -rf /usr/local/lib/android
+          fi
+          
+          if [ -d "/opt/ghc" ]; then
+            echo "Removing GHC..."
+            sudo rm -rf /opt/ghc
+          fi
+          
+          if [ -d "/opt/hostedtoolcache/CodeQL" ]; then
+            echo "Removing CodeQL..."
+            sudo rm -rf /opt/hostedtoolcache/CodeQL
+          fi
+          
+          # Additional cleanup
+          echo "Docker system cleanup..."
+          sudo docker system prune -af
+          
+          echo "APT cleanup..."
+          sudo apt-get clean
+          
+          echo ""
+          echo "=== Final disk usage ==="
+          df -h
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
# Jira - https://dsai.atlassian.net/browse/CHAT-720

## Fix GitHub Actions "No space left on device" error during Docker build

### Problem
After merging https://github.com/ssc-dsai/canchat-v2/pull/188, the Docker build process failed on GitHub-hosted runner with a "No space left on device" error. This occurred because the new wiki grounding functionality requires downloading large AI models (txtai-wikipedia ~4-6GB, Helsinki translation model ~300MB) during the Docker build, which exhausted the ~14GB available disk space on GitHub runners.

### Solution
Added intelligent disk space cleanup to the Docker build workflow before starting the build process to purge unused software typically found in Ubuntu runners. This should free up enough space for the build to fully complete.

### Changes
- **Enhanced `docker-build.yaml`**: Added comprehensive disk analysis and cleanup step

### What the cleanup does
1. **Analyzes current disk usage** - Shows before/after disk space
2. **Identifies large directories** - Checks what actually exists before removing
3. **Removes unused software** - Only removes directories that exist:
   - .NET SDK (`/usr/share/dotnet`)
   - Android SDK (`/usr/local/lib/android`) 
   - GHC Haskell (`/opt/ghc`)
   - CodeQL tools (`/opt/hostedtoolcache/CodeQL`)
4. **Docker cleanup** - Removes unused Docker images/containers from the runner
5. **APT cleanup** - Clears package cache

### Expected outcome
- Frees up ~6-10GB of disk space on GitHub runners
- Allows Docker builds with large AI models to complete successfully
- Provides detailed logging of space usage for troubleshooting

### Testing
This change should resolve the "No space left on device" errors seen in recent builds while maintaining all existing functionality.