### PR TITLE
ci(docker): set docker cache location on private runner.

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -88,6 +88,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=${{ steps.cache-meta.outputs.tags }}
+          cache-to: type=local,dest=/var/lib/docker/cache
           # cache-to: type=registry,ref=${{ steps.cache-meta.outputs.tags }},mode=max  # Disabled to avoid disk space issues
           build-args: |
             BUILD_HASH=${{ github.sha }}


### PR DESCRIPTION
Set docker cache on the private runner: https://github.com/ssc-dsai-iac/canchat-v2-iac/pull/138/files#diff-44e01d8ec815615c0566c718cf577735b89cc87572e85528e98e90cf260ab9deR75-R76