### PR TITLE
feat(middleware): add custom headers to Wikipedia API requests for improved compatibility

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -98,8 +98,13 @@ def fetch_wikipedia_title_and_excerpt(url: str) -> tuple[str, str]:
         else:
             return "", ""
 
-        # Make request with timeout
-        response = requests.get(api_url, timeout=3)
+        # Make request with timeout and proper headers
+        headers = {
+            "User-Agent": "CanChat/2.0 (https://github.com/ssc-dsai/canchat-v2; contact@example.com) requests/2.31.0",
+            "Accept": "application/json",
+            "Accept-Language": "en-US,en;q=0.9,fr;q=0.8",
+        }
+        response = requests.get(api_url, timeout=3, headers=headers)
         if response.status_code == 200:
             data = response.json()
             title = data.get("title", "")


### PR DESCRIPTION
So quick bug I just resolved regarding the wiki grounding on corporate network, we were missing a header in the request for the source pages and French kept defaulting to English
 
Good thing I came in to office today and happened to test this, I wouldn't have known while at home
Dev environment is doing the same thing so I can only assume anyone using dev will encounter this
 
 
Ask it this in dev and you'll see what I mean:
"qui est le premier ministre du Canada ?"
 
The sources give a 403 in the k8s logs but when you visit the French equivalent to those pages, they exist and you can visit them (so it wasn't a firewall issue blocking access), its purely a request-based permissions issue - lack of headers


<img width="2662" height="632" alt="image" src="https://github.com/user-attachments/assets/21ebe336-d896-4802-ba02-f9355fa83204" />

 