### PR TITLE
feat(docker): add cleanup steps to free up disk space during and after build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -45,6 +45,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Cleanup Docker to free space
+        run: |
+          echo "=== Initial disk usage ==="
+          df -h
+          echo "=== Docker system info ==="
+          docker system df || true
+          echo "=== Aggressive cleanup ==="
+          docker system prune -a -f --volumes || true
+          docker builder prune -a -f || true
+          # Clean up the cache directory that's causing the space issue
+          sudo rm -rf /var/lib/docker/cache/* || true
+          # Clean up any tmp directories
+          sudo find /tmp -name "docker*" -type d -exec rm -rf {} + 2>/dev/null || true
+          echo "=== Post-cleanup disk usage ==="
+          df -h
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -106,6 +122,12 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+
+      - name: Cleanup after build
+        if: always()
+        run: |
+          docker system prune -f || true
+          df -h
 
   merge-main-images:
     runs-on: arc-ssc-dsai


### PR DESCRIPTION
## We have an accumulation of docker images in our cache that are not being pruned in /var/lib/docker/cache/, which eventually led to this error:

[build-main-image (linux/amd64)](https://github.com/ssc-dsai/canchat-v2/actions/runs/17332165035/job/49210477101#step:9:4698)
buildx failed with: ERROR: failed to build: failed to solve: error writing layer blob: rpc error: code = Unknown desc = mkdir /var/lib/docker/cache/ingest/37a3cba545c9a2832ea83e8f4845ac4ddb131dec9e2c04c86afb225380b4f9ce: no space left on device

This build step ensures there is always image space.