### PR TITLE
chore(python/build): remove unused hatch build configs to allow use of uv.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,127 +5,11 @@ authors = [
     { name = "Timothy Jaeryang Baek", email = "tim@openwebui.com" }
 ]
 license = { file = "LICENSE" }
-dependencies = [
-    "fastapi==0.111.0",
-    "uvicorn[standard]==0.30.6",
-    "pydantic>=2.10.6,<3.0.0",
-    "python-multipart==0.0.18",
 
-    "Flask==3.1.0",
-    "Flask-Cors==5.0.0",
-
-    "python-socketio==5.13.0",
-    "python-jose==3.3.0",
-    "passlib[bcrypt]==1.7.4",
-
-    "requests==2.32.3",
-    "aiohttp==3.11.8",
-    "async-timeout",
-    "aiocache",
-    "aiofiles",
-
-    "sqlalchemy==2.0.32",
-    "alembic==1.14.0",
-    "peewee==3.17.8",
-    "peewee-migrate==1.12.2",
-    "psycopg2-binary==2.9.9",
-    "pgvector>=0.4.1",
-    "PyMySQL==1.1.1",
-    "bcrypt==4.2.0",
-
-    "pymongo",
-    "redis",
-    "boto3==1.35.53",
-
-    "argon2-cffi==23.1.0",
-    "APScheduler==3.10.4",
-
-    "openai",
-    "anthropic",
-    "google-generativeai==0.8.1",
-    "tiktoken",
-
-    "langchain==0.3.26",
-    "langchain-community==0.3.26",
-
-    "fastmcp==2.5.2",
-    "pytz==2025.2",
-    "crewai==0.140.0",
-    "crewai-tools[mcp]==0.49.0",
-    "protobuf>=5.26.1,<6.0.0",
-    "grpcio>=1.49.1,<=1.67.1",
-    "azure-storage-blob==12.25.1",
-
-    "fake-useragent==1.5.1",
-    "chromadb==0.5.23",
-    "pymilvus==2.5.0",
-    "qdrant-client~=1.12.0",
-    "opensearch-py==2.7.1",
-
-    "transformers>=4.46.0,<5.0.0",
-    "sentence-transformers>=5.0.0",
-    "colbert-ai==0.2.21",
-    "einops==0.8.0",
-
-    # txtai-wikipedia Wiki Grounding dependencies
-    "txtai[graph]==9.0.0",
-    "sacremoses==0.1.1",
-
-    "ftfy==6.2.3",
-    "pypdf>=5.0.0",
-    "fpdf2==2.8.2",
-    "pymdown-extensions==10.11.2",
-    "docx2txt==0.8",
-    "python-pptx==1.0.0",
-    "unstructured==0.15.9",
-    "nltk==3.9.1",
-    "Markdown==3.7",
-    "pypandoc==1.13",
-    "pandas==2.2.3",
-    "openpyxl==3.1.5",
-    "pyxlsb==1.0.10",
-    "xlrd==2.0.1",
-    "validators==0.34.0",
-    "psutil",
-    "sentencepiece",
-    "soundfile==0.12.1",
-
-    "opencv-python-headless==4.10.0.84",
-    "rapidocr-onnxruntime==1.3.24",
-    "rank-bm25==0.2.2",
-
-    "faster-whisper==1.0.3",
-
-    "PyJWT[crypto]==2.10.1",
-    "authlib==1.3.2",
-
-    "black==24.8.0",
-    "langfuse==2.44.0",
-    "youtube-transcript-api==0.6.3",
-    "pytube==15.0.0",
-
-    "extract_msg",
-    "pydub",
-    "duckduckgo-search~=7.2.1",
-
-    "google-api-python-client",
-    "google-auth-httplib2",
-    "google-auth-oauthlib",
-
-    "docker~=7.1.0",
-    "pytest~=8.3.2",
-    "pytest-docker~=3.1.1",
-    "moto[s3]>=5.0.26",
-
-    "googleapis-common-protos==1.63.2",
-    "google-cloud-storage==2.19.0",
-
-    "ldap3==2.9.1",
-    "gcp-storage-emulator>=2024.8.3",
-]
 readme = "README.md"
 requires-python = ">= 3.11, < 3.13.0a1"
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
+
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
@@ -138,6 +22,9 @@ classifiers = [
 
 [project.scripts]
 open-webui = "open_webui:app"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["backend/requirements.txt"]}
 
 # [build-system]
 # requires = ["hatchling"]


### PR DESCRIPTION
I'm doing this because I'm tired of doing it locally all the time. `uv` is way faster than `pip` and offers management of `venv`s.