### PR TITLE
Fix SBOM compare check both files

### DIFF
--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -15,11 +15,13 @@ on:
     branches:
       - main
       - dev
+      - fix-sbom-compare-check-both-files
 
   pull_request:
     branches:
       - main
       - dev
+      - fix-sbom-compare-check-both-files
 
 permissions:
     actions: read

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -113,19 +113,20 @@ jobs:
         id: compare-sbom-cdx
         continue-on-error: true
         run: |
-          if test -f .sbom/previous.cdx.json; then
+          if [ -f .sbom/previous.cdx.json ] && [ -f .sbom/current.cdx.json ]; then
             sbomdiff .sbom/previous.cdx.json .sbom/current.cdx.json --sbom cyclonedx --format text > .sbom/comparison.cdx.md
           else
-            echo "Unable to use the previous commit CDX SBOM. A previous commit may not exist." > .sbom/comparison.cdx.md
+            echo "Unable to compare CDX SBOMs. A previous commit for this branch may not exist." > .sbom/comparison.cdx.md
           fi
 
       - name: Compare SPDX SBOMs
         id: compare-sbom-spdx
+        continue-on-error: true
         run: |
-          if test -f .sbom/previous.spdx.json; then
+          if [ -f .sbom/previous.spdx.json ] && [ -f .sbom/current.spdx.json ]; then
             sbomdiff .sbom/previous.spdx.json .sbom/current.spdx.json --sbom spdx --format text > .sbom/comparison.spdx.md
           else
-            echo "Unable to use the previous run SPDX SBOM. The previous run may have failed." > .sbom/comparison.spdx.md
+            echo "Unable to compare SPDX SBOMs. The previous run may have failed." > .sbom/comparison.spdx.md
           fi
 
       - name: Get PR number

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -15,13 +15,11 @@ on:
     branches:
       - main
       - dev
-      - fix-sbom-compare-check-both-files
 
   pull_request:
     branches:
       - main
       - dev
-      - fix-sbom-compare-check-both-files
 
 permissions:
     actions: read
@@ -128,7 +126,7 @@ jobs:
           if [ -f .sbom/previous.spdx.json ] && [ -f .sbom/current.spdx.json ]; then
             sbomdiff .sbom/previous.spdx.json .sbom/current.spdx.json --sbom spdx --format text > .sbom/comparison.spdx.md
           else
-            echo "Unable to compare SPDX SBOMs. The previous run may have failed." > .sbom/comparison.spdx.md
+            echo "Unable to compare SPDX SBOMs. The previous run may have failed to upload a file." > .sbom/comparison.spdx.md
           fi
 
       - name: Get PR number


### PR DESCRIPTION
# Pull Request Checklist

- targeting DEV branch
- FIX occasional failure - additional checks and continue-on-error
- TESTED in this separate testing branch
- no code review
- category: **fix**

### Description

- fixing a bug, some step failures are expected, however were setting error condition for entire job

### Fixed

- in file comparison, check in advance for file existence of both files instead of just one
- added one continue-on-error, it's preferable that any other artifacts are uploaded, instead of crashing the job
