### PR TITLE
fix(socketio): update dependency with a fix for the rediss URL scheme.

### DIFF
--- a/CHANGELOG-FR.md
+++ b/CHANGELOG-FR.md
@@ -5,6 +5,12 @@ Tous les changements notables apportés à ce projet seront documentés dans ce 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
 et ce projet adhère au [Versionnage sémantique](https://semver.org/lang/fr/spec/v2.0.0.html).
 
+## [0.5.7-ccv2-1.14.1] - 2026-04-07
+
+### Corrigé
+
+- **Schéma d'URL Redis de socketio**: Mettre à jour python-socketio vers la version 5.16.1, ce qui corrige une régression de la version 5.14.0.
+
 ## [0.5.7-ccv2-1.14.0] - 2026-03-23
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7-ccv2-1.14.1] - 2026-04-07
+
+### Fixed
+
+- **socketio rediss URL Scheme**: Update python-socketio to 5.16.1 which fixes a reversion from 5.14.0.
+
 ## [0.5.7-ccv2-1.14.0] - 2026-03-23
 
 ### Added

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -56,7 +56,7 @@ Flask==3.1.3
 Flask-Cors==6.0.2
 pydantic>=2.11.9,<2.12  # crewai 1.7.2 requires ~=2.11.9
 python-multipart==0.0.22
-python-socketio==5.14.0
+python-socketio==5.16.1
 uvicorn[standard]>=0.31.1  # crewai 1.7.2 -> mcp>=1.16.0 -> uvicorn>=0.31.1
 werkzeug==3.1.6
 

--- a/uv.lock
+++ b/uv.lock
@@ -3588,7 +3588,7 @@ requires-dist = [
     { name = "pytest-mock", specifier = "~=3.15.1" },
     { name = "python-multipart", specifier = "==0.0.22" },
     { name = "python-pptx", specifier = "==1.0.2" },
-    { name = "python-socketio", specifier = "==5.14.0" },
+    { name = "python-socketio", specifier = "==5.16.1" },
     { name = "pytube", specifier = "==15.0.0" },
     { name = "pytz", specifier = "==2025.2" },
     { name = "pyxlsb", specifier = "==1.0.10" },
@@ -4904,15 +4904,15 @@ wheels = [
 
 [[package]]
 name = "python-socketio"
-version = "5.14.0"
+version = "5.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bidict" },
     { name = "python-engineio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/bf/bbc41facdb33a7f440a39f213e59202032106b42df4667a32ef4c9ffe604/python_socketio-5.14.0.tar.gz", hash = "sha256:d057737f658b3948392ff452a5c865c5ccc969859c37cf095a73393ce755f98e", size = 122099, upload-time = "2025-09-30T19:30:40.902Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/81/cf8284f45e32efa18d3848ed82cdd4dcc1b657b082458fbe01ad3e1f2f8d/python_socketio-5.16.1.tar.gz", hash = "sha256:f863f98eacce81ceea2e742f6388e10ca3cdd0764be21d30d5196470edf5ea89", size = 128508, upload-time = "2026-02-06T23:42:07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/8d/f41abde5846c456b33f25e7fa71d8b8ad78785bb812ef0f2393cda2caaf2/python_socketio-5.14.0-py3-none-any.whl", hash = "sha256:7de5ad8a55efc33e17897f6cf91d20168d3d259f98c38d38e2940af83136d6f8", size = 78438, upload-time = "2025-09-30T19:30:39.134Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c7/deb8c5e604404dbf10a3808a858946ca3547692ff6316b698945bb72177e/python_socketio-5.16.1-py3-none-any.whl", hash = "sha256:a3eb1702e92aa2f2b5d3ba00261b61f062cce51f1cfb6900bf3ab4d1934d2d35", size = 82054, upload-time = "2026-02-06T23:42:05.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Quick for the regression which broke the use of the secure redis URL schema. 