### PR TITLE
fix: sanitize markdown URLs in links and images

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
@@ -11,6 +11,8 @@
 	import { WEBUI_BASE_URL } from '$lib/constants';
 	import { copyToClipboard, unescapeHtml } from '$lib/utils';
 
+	const sanitizeUrl = (url: string) => url.split('?')[0];
+
 	import Image from '$lib/components/common/Image.svelte';
 	import KatexRenderer from './KatexRenderer.svelte';
 	import Source from './Source.svelte';
@@ -36,14 +38,16 @@
 		{/if}
 	{:else if token.type === 'link'}
 		{#if token.tokens}
-			<a href={token.href} target="_blank" rel="nofollow" title={token.title}>
+			<a href={sanitizeUrl(token.href)} target="_blank" rel="nofollow" title={token.title}>
 				<svelte:self id={`${id}-a`} tokens={token.tokens} {onSourceClick} />
 			</a>
 		{:else}
-			<a href={token.href} target="_blank" rel="nofollow" title={token.title}>{token.text}</a>
+			<a href={sanitizeUrl(token.href)} target="_blank" rel="nofollow" title={token.title}
+				>{token.text}</a
+			>
 		{/if}
 	{:else if token.type === 'image'}
-		<Image src={token.href} alt={token.text} />
+		<Image src={sanitizeUrl(token.href)} alt={token.text} />
 	{:else if token.type === 'strong'}
 		<strong>
 			<svelte:self id={`${id}-strong`} tokens={token.tokens} {onSourceClick} />


### PR DESCRIPTION
# Changelog Entry

### Description

Functionality was introduced to remove query strings from URLs in response to security concerns brought up in CHAT-1687.  This applies to links with nested tokens, plain text links, and image sources in LLM-generated markdown.

### Security

- Modified ./canchat-v2/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
Added sanitizeUrl function to strip all data in rendered links starting from after the query mark.


---

### Additional Information

- Please see [https://dsai.atlassian.net/browse/CHAT-1687](CHAT-1687)

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [✓] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
