### PR TITLE
feat: add TeX wrapping functionality to processResponseContent

### DIFF
--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { processResponseContent } from './index';
+
+describe('processResponseContent — undelimited TeX wrapping', () => {
+	// The exact failing case from the user report
+	it('wraps \\boxed{...} in $ delimiters', () => {
+		const input = '**Final Answer:**\n\\boxed{4\\ \\text{gallons}}';
+		const output = processResponseContent(input);
+		expect(output).toContain('$\\boxed{4\\ \\text{gallons}}$');
+		// The surrounding markdown should be untouched
+		expect(output).toContain('**Final Answer:**');
+	});
+
+	it('wraps \\frac{...}{...} in $ delimiters', () => {
+		const input = 'The answer is \\frac{1}{2} of the total.';
+		const output = processResponseContent(input);
+		expect(output).toContain('$\\frac{1}{2}$');
+	});
+
+	it('wraps \\sqrt{...} in $ delimiters', () => {
+		const input = 'The hypotenuse is \\sqrt{a^2 + b^2}.';
+		const output = processResponseContent(input);
+		expect(output).toContain('$\\sqrt{a^2 + b^2}$');
+	});
+
+	it('does not double-wrap already-delimited inline math', () => {
+		const input = 'Already wrapped: $\\boxed{x}$';
+		const output = processResponseContent(input);
+		// Should not become $$\boxed{x}$$ or $$$\boxed{x}$$$
+		expect(output).toBe('Already wrapped: $\\boxed{x}$');
+	});
+
+	it('does not double-wrap already-delimited block math', () => {
+		const input = '$$\n\\boxed{x}\n$$';
+		const output = processResponseContent(input);
+		expect(output).toBe('$$\n\\boxed{x}\n$$');
+	});
+
+	it('does not touch TeX inside a code block', () => {
+		const input = '```\n\\boxed{not math}\n```';
+		const output = processResponseContent(input);
+		expect(output).toBe('```\n\\boxed{not math}\n```');
+	});
+
+	it('does not touch TeX inside inline code', () => {
+		const input = 'Use the `\\boxed{x}` command in LaTeX.';
+		const output = processResponseContent(input);
+		expect(output).toBe('Use the `\\boxed{x}` command in LaTeX.');
+	});
+
+	it('handles nested braces in \\boxed', () => {
+		const input = '\\boxed{\\frac{1}{2}}';
+		const output = processResponseContent(input);
+		expect(output).toContain('$\\boxed{\\frac{1}{2}}$');
+	});
+
+	it('trims leading/trailing whitespace', () => {
+		expect(processResponseContent('  hello  ')).toBe('hello');
+	});
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -203,8 +203,48 @@ export const sanitizeResponseContent = (content: string): string => {
 	}).trim();
 };
 
+/**
+ * Wraps bare (undelimited) TeX math commands in $ delimiters so KaTeX can render them.
+ * Some LLMs (e.g. Cohere Command) emit raw LaTeX like \boxed{...} without surrounding
+ * math delimiters. This preprocessor detects those and wraps them before lexing.
+ *
+ * Protected regions (code blocks, existing math delimiters) are left untouched.
+ */
+const wrapUndelimitedTexExpressions = (content: string): string => {
+	// Split into protected segments (code fences, inline code, existing math) and plain text.
+	// The capturing group means odd-indexed elements are the protected segments.
+	const PROTECTED_RE =
+		/(```[\s\S]*?```|`[^`\n]+`|\$\$[\s\S]*?\$\$|\$[^\n$]+\$|\\\([\s\S]*?\\\)|\\\[[\s\S]*?\\\])/g;
+
+	const segments = content.split(PROTECTED_RE);
+
+	// Brace group pattern: handles up to 2 levels of inner nesting
+	const B = `\\{(?:[^{}]|\\{(?:[^{}]|\\{[^{}]*\\})*\\})*\\}`;
+
+	// Single-pass combined regex — prevents double-wrapping when commands are nested
+	// (e.g. \boxed{\frac{1}{2}} would be double-wrapped by two sequential replacements).
+	// Alternation order matters: the longer/outer command is tried first so the inner
+	// occurrence is consumed as part of it rather than matched separately.
+	const COMBINED_RE = new RegExp(
+		`\\\\(?:` +
+			// Single brace group: \boxed, \sqrt, \binom family, \underbrace, \overbrace, \dfrac, \tfrac
+			`(?:boxed|dfrac|tfrac|binom|dbinom|tbinom|underbrace|overbrace|sqrt)\\s*${B}` +
+			// Two brace groups: \frac{num}{den}
+			`|frac\\s*${B}\\s*${B}` +
+			`)`,
+		'g'
+	);
+
+	return segments
+		.map((seg, i) => {
+			if (i % 2 === 1) return seg; // protected segment — leave as-is
+			return seg.replace(COMBINED_RE, (match) => `$${match}$`);
+		})
+		.join('');
+};
+
 export const processResponseContent = (content: string) => {
-	return content.trim();
+	return wrapUndelimitedTexExpressions(content.trim());
 };
 
 export function unescapeHtml(html: string) {


### PR DESCRIPTION
https://dsai.atlassian.net/browse/CHAT-1724


## Markdown renderer: handle undelimited TeX from Cohere Command models (and potentially other models that might occasionally emit this)

### Problem

Cohere Command models (and potentially others) occasionally emit LaTeX math commands directly in their markdown output **without surrounding math delimiters**. For example:

Final Answer:
\boxed{4\ \text{gallons}}



The KaTeX marked extension only activates on explicit delimiters (`$...$`, `$$...$$`, `\(...\)`, `\[...\]`). Without them, `\boxed{4\ \text{gallons}}` falls through as plain text and renders literally in the UI instead of as a formatted math expression.

### Root Cause

This is a joint model/client issue. The model outputs valid LaTeX syntax but omits the delimiters that signal to the renderer that math is intended. The client has no mechanism to detect and recover from this.

### Solution

Added `wrapUndelimitedTexExpressions()` in `src/lib/utils/index.ts`, called from `processResponseContent()` before the marked lexer runs.

The function:
1. **Splits the content** into protected segments (code fences, inline code, already-delimited math) and plain text, so existing rendering is never disturbed
2. **Applies a single-pass regex** across unprotected segments to detect bare math-exclusive TeX commands (`\boxed`, `\frac`, `\sqrt`, `\binom`, `\dfrac`, `\tfrac`, `\underbrace`, `\overbrace`) with up to two levels of brace nesting
3. **Wraps matched expressions** in `$...$` so KaTeX picks them up normally

A single-pass combined regex is used (rather than sequential replacements) to prevent double-wrapping when commands are nested - e.g. `\boxed{\frac{1}{2}}` must become `$\boxed{\frac{1}{2}}$`, not `$\boxed{$\frac{1}{2}$}$`.

### Tests

Unit tests added in `src/lib/utils/index.test.ts` (run with `npm run test:frontend`):

- Wraps `\boxed{...}`, `\frac{...}{...}`, `\sqrt{...}` when bare
- Does **not** double-wrap already-delimited math (`$...$`, `$$...$$`)
- Does **not** touch TeX inside code blocks or inline code
- Handles nested commands (`\boxed{\frac{1}{2}}`) without double-wrapping

### Files Changed

- `src/lib/utils/index.ts` — `processResponseContent` now pre-processes content through `wrapUndelimitedTexExpressions`
- `src/lib/utils/index.test.ts` — new Vitest unit tests
