### PR TITLE
fix(github/workflows/docker-build): check if cache folder exists befo…

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -67,7 +67,7 @@ jobs:
           echo "Cleaning up Docker cache..."
           docker buildx prune --filter type=local --filter until=336h --force
           echo "Overall disk usage on the cache volume:"
-          df -h /var/lib/docker/cache
+          test -d /var/lib/docker/cache && df -h /var/lib/docker/cache
       - name: Build Docker image (latest)
         uses: docker/build-push-action@v7
         id: build


### PR DESCRIPTION
Quick fix to ensure that workflow continues.

Example of failure: https://github.com/ssc-dsai/canchat-v2/actions/runs/26577531240/job/78880608919