### PR TITLE
SBOM compare for pr generate prev from base

### DIFF
--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -61,16 +61,14 @@ jobs:
         continue-on-error: true
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.head_ref }}" \
-              | jq -r '.workflow_runs
-                | if length > 0 then .[0].artifacts_url else empty end')
+            BRANCH_WITH_CARRYOVER=${{ github.head_ref }}
           else
-            ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
-              | jq -r '.workflow_runs
-                | if length > 0 then .[0].artifacts_url else empty end')
+            BRANCH_WITH_CARRYOVER=${{ github.ref_name }}
           fi
+          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${BRANCH_WITH_CARRYOVER}" \
+            | jq -r '.workflow_runs
+              | if length > 0 then .[0].artifacts_url else empty end')
           echo "Artifacts URL: ${ARTIFACTS_URL}"
           ARCHIVE_DOWNLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARTIFACTS_URL}?name=carryover.zip" \
             | jq -r '.artifacts

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -65,8 +65,9 @@ jobs:
           else
             BRANCH_WITH_CARRYOVER=${{ github.ref_name }}
           fi
-          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${BRANCH_WITH_CARRYOVER}" \
+          WORKFLOW_HISTORY_URL="https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${BRANCH_WITH_CARRYOVER}"
+          echo "Workflow History URL: ${WORKFLOW_HISTORY_URL}"
+          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${WORKFLOW_HISTORY_URL}" \
             | jq -r '.workflow_runs
               | if length > 0 then .[0].artifacts_url else empty end')
           echo "Artifacts URL: ${ARTIFACTS_URL}"

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -1,13 +1,13 @@
-# target steps:
-# download current SBOM (from github - SPDX format)
-# download previous SBOM (from previous run artifact)
-# - lack of github SBOM sort order detects changes incorectly, solution is to sort
-# - occasional workflow failures and artifacts expiring will cause issues with previous artefact availability for a current run
-#  - solution: create a 'previous' and 'current' SBOM in the same script (use CDX, newer more robust format)
-# DIFF the SPDX files (prev from last action run)
-# DIFF the CDX files (prev from last commit)
-# create CSVs for easier human usability (sbom-to-excel would be nicer but the conversion tool is not robust and crashing on content)
-# upload carryover and other artifacts
+# download previous compare history for this branch
+# - continue-on-error whenever this is a first run and no file is available to download
+# create a current SBOM
+# create a previous SBOM from:
+#  - pull_request, use base repository
+#  - push, use the previous commit
+#  - workflow_dispatch, use the previous commit (same as push)
+# DIFF the SBOMs and report
+# create CSVs for easier human use
+# upload artifacts (for sbom-reports.zip, and carryover.zip)
 
 name: SBOM compare
 on:

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -83,18 +83,18 @@ jobs:
         id: previous-sbom-cdx
         run: |
           echo "github.event_name = ${{ github.event_name }}"
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            git checkout ${{ github.base_ref }}
+            cdxgen -o .sbom/previous.cdx.json --json-pretty
+            git checkout ${{ github.head_ref }}
+          elif [ "${{ github.event_name }}" == "push" ]; then
             git checkout HEAD^
             cdxgen -o .sbom/previous.cdx.json --json-pretty
             git checkout -
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            git checkout ${{ github.base_ref }}
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            git checkout HEAD^
             cdxgen -o .sbom/previous.cdx.json --json-pretty
-            git checkout ${{ github.head_ref }}
-          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            git checkout ${{ github.base_ref }}
-            cdxgen -o .sbom/previous.cdx.json --json-pretty
-            git checkout ${{ github.head_ref }}
+            git checkout -
           else
             cp .sbom/current.cdx.json .sbom/previous.cdx.json
           fi
@@ -112,13 +112,13 @@ jobs:
       - name: Get PR number
         id: get-pr-number
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
             PR_NUMBER=$(jq -r '.number' "$GITHUB_EVENT_PATH")
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "pr_number=none (workflow_dispatch)" >> $GITHUB_OUTPUT
-          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          elif [ "${{ github.event_name }}" == "push" ]; then
             echo "pr_number=none (push)" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "pr_number=none (workflow_dispatch)" >> $GITHUB_OUTPUT
           else
             echo "pr_number=none" >> $GITHUB_OUTPUT
           fi
@@ -132,11 +132,11 @@ jobs:
           
           # CDX version
           echo "" >> .sbom/comparison.md
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "### Comparison of current CDX SBOM with BASE repository" >> .sbom/comparison.md
+          elif [ "${{ github.event_name }}" == "push" ]; then
             echo "### Comparison of current CDX SBOM with previous commit" >> .sbom/comparison.md
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            echo "### Comparison of current CDX SBOM with base repo" >> .sbom/comparison.md
-          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "### Comparison of current CDX SBOM with base repo" >> .sbom/comparison.md
           else
             echo "### Comparison not completed" >> .sbom/comparison.md

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all previous commits, changed from 2 (last) to 0 (all)
-#          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref }}
          
       - name: Install Dependencies
         run: |
@@ -135,7 +135,11 @@ jobs:
 
           # prepend current comparison log to the top of the comparison history file (most recent first)
           echo "" >> .sbom/comparison.md
+          if test -f .sbom/comparison-history.md; then cp .sbom/comparison-history.md .sbom/old-comparison-history.md; fi
           cp .sbom/comparison.md .sbom/comparison-history.md
+          if test -f .sbom/old-comparison-history.md; then 
+            cat .sbom/old-comparison-history.md >> .sbom/comparison-history.md
+          fi
           cat .sbom/comparison-history.md >> $GITHUB_STEP_SUMMARY
 
       - name: show artifacts in run log before upload

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -70,12 +70,6 @@ jobs:
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
           curl -sS -L -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "${ARCHIVE_DOWNLOAD_URL}"
-          
-      - name: unzip carryover
-        id: unzip-carryover
-        continue-on-error: true
-        run: |
-          ls -R .sbom
           unzip .sbom/carryover.zip -d .sbom
           ls -R .sbom
           
@@ -116,14 +110,17 @@ jobs:
         run: sbomdiff .sbom/previous.cdx.json .sbom/current.cdx.json --sbom cyclonedx --format text > .sbom/comparison.cdx.md
 
       - name: Get PR number
-        id: pr
+        id: get-pr-number
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            # Extract PR number from the event payload
             PR_NUMBER=$(jq -r '.number' "$GITHUB_EVENT_PATH")
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          else
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "pr_number=none (workflow_dispatch)" >> $GITHUB_OUTPUT
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "pr_number=none (push)" >> $GITHUB_OUTPUT
+          else
+            echo "pr_number=none" >> $GITHUB_OUTPUT
           fi
        
       - name: create summary
@@ -135,7 +132,15 @@ jobs:
           
           # CDX version
           echo "" >> .sbom/comparison.md
-          echo "### Comparison of current CDX SBOM with previous commit" >> .sbom/comparison.md
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "### Comparison of current CDX SBOM with previous commit" >> .sbom/comparison.md
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            echo "### Comparison of current CDX SBOM with base repo" >> .sbom/comparison.md
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "### Comparison of current CDX SBOM with base repo" >> .sbom/comparison.md
+          else
+            echo "### Comparison not completed" >> .sbom/comparison.md
+          fi
           cat .sbom/comparison.cdx.md >> .sbom/comparison.md # copy differnces to the historic version
 
           # prepend current comparison log to the top of the comparison history file (most recent first)

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -63,15 +63,20 @@ jobs:
           echo "token: ${{ secrets.GITHUB_TOKEN }}"
           LAST_WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}"
-            | jq -r '.workflow_id
+            | jq -r '.workflow_runs
               | if length > 0 then .[0].id else empty end')
-          echo "Last successful run workflow id: ${LAST_WORKFLOW_ID }"
+          echo "Last successful run workflow id: ${LAST_WORKFLOW_ID}"
           LAST_ARTIFACT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip"
-            | jq -r '.id
+            | jq -r '.artifacts
               | if length > 0 then .[0].id else empty end')
-          echo "Last artifact id: ${LAST_WORKFLOW_ID}"
+          echo "Last artifact id: ${LAST_ARTIFACT_ID}"
           curl -o .sbom/carryover.zip "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
+
+            | jq -r '.workflow_runs 
+              | map(select(.name == "SBOM compare"))  # Replace "Your Workflow Name" with the desired name
+              | if length > 1 then .[1].id else empty end')  # Fetch the second most recent run with the matching name
+
 
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -130,7 +130,7 @@ jobs:
           # CDX version
           echo "" >> .sbom/comparison.md
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "### Comparison of current CDX SBOM with BASE repository" >> .sbom/comparison.md
+            echo "### Comparison of current CDX SBOM with base repository" >> .sbom/comparison.md
           elif [ "${{ github.event_name }}" == "push" ]; then
             echo "### Comparison of current CDX SBOM with previous commit" >> .sbom/comparison.md
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -52,8 +52,26 @@ jobs:
           # sbomdiff (create a DIFF from either format SBOM into TXT)
           pip install sbomdiff
 
-      - name: setup artefact folder
+      - name: setup artifact folder
         run: mkdir .sbom
+
+      - name: Get Previous Run ID
+        id: get-run-id
+        # fail expected if no previous github action run exists - allow the script to continue
+        continue-on-error: true
+        run: |
+          echo "Github token: ${{ secrets.GITHUB_TOKEN }}"
+          LAST_WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
+            | jq -r '.workflow_id
+              | if length > 0 then .[0].id else empty end')
+          echo "Last successful run workflow id: ${{ LAST_WORKFLOW_ID }}"
+          LAST_ARTIFACT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${{ LAST_WORKFLOW_ID }}/artifacts?name=carryover.zip" \
+            | jq -r '.id
+              | if length > 0 then .[0].id else empty end')
+          echo "Last artifact id: ${{ LAST_WORKFLOW_ID }}"
+          curl -o .sbom/carryover.zip "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${{ LAST_ARTIFACT_ID }}/zip"
 
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx
@@ -109,6 +127,11 @@ jobs:
           echo "" >> .sbom/comparison.md
           echo "### Comparison of current CDX SBOM with previous commit" >> .sbom/comparison.md
           cat .sbom/comparison.cdx.md >> .sbom/comparison.md # copy differnces to the historic version
+
+          # prepend current comparison log to the top of the comparison history file (most recent first)
+          echo "" >> .sbom/comparison.md
+          cp .sbom/comparison.md .sbom/comparison-history.md
+          cat .sbom/comparison-history.md >> $GITHUB_STEP_SUMMARY
 
       - name: show artifacts in run log before upload
         run: ls -R .sbom    # gut check

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -73,6 +73,7 @@ jobs:
           echo "Last artifact id: ${LAST_ARTIFACT_ID}"
           curl -o .sbom/carryover.zip -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
+          ls -R .sbom
 
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -115,10 +115,6 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             PR_NUMBER=$(jq -r '.number' "$GITHUB_EVENT_PATH")
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            echo "pr_number=none (push)" >> $GITHUB_OUTPUT
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "pr_number=none (workflow_dispatch)" >> $GITHUB_OUTPUT
           else
             echo "pr_number=none" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: unzip carryover
         id: unzip-carryover
+        continue-on-error: true
         run: |
           ls -R .sbom
           unzip .sbom/carryover.zip -d .sbom

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -69,19 +69,15 @@ jobs:
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
-          #curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
-          #curl -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "$ARCHIVE_DOWNLOAD_URL"
-          wget --header="Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$ARCHIVE_DOWNLOAD_URL" -O .sbom/carryover.zip
+          curl -sS -L -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "${ARCHIVE_DOWNLOAD_URL}"
           
       - name: unzip carryover
         id: unzip-carryover
         continue-on-error: true
         run: |
-          cd .sbom
-          cat carryover.zip
-          unzip carryover.zip
-          ls
-          cd ..
+          ls -R .sbom
+          unzip .sbom/carryover.zip -d .sbom
+          ls -R .sbom
           
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -60,20 +60,16 @@ jobs:
         # fail expected if no previous github action run exists - allow the script to continue
         continue-on-error: true
         run: |
-          echo "token: ${{ secrets.GITHUB_TOKEN }}"
-          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
+          ARTIFACTS_URL=$(curl -s "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
             | jq -r '.workflow_runs
               | if length > 0 then .[0].artifacts_url else empty end')
           echo "Artifacts URL: ${ARTIFACTS_URL}"
-          ARCHIVE_DOWNLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARTIFACTS_URL}?name=carryover.zip" \
+          ARCHIVE_DOWNLOAD_URL=$(curl -s "${ARTIFACTS_URL}?name=carryover.zip" \
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
           # try noauth
           curl -o .sbom/carryover.zip "${ARCHIVE_DOWNLOAD_URL}"
-          # try auth
-          curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
 
       - name: unzip carryover
         id: unzip-carryover

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -66,13 +66,12 @@ jobs:
             | jq -r '.workflow_runs
               | if length > 0 then .[0].id else empty end')
           echo "Last successful run workflow id: ${LAST_WORKFLOW_ID}"
-          LAST_ARTIFACT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          ARCHIVE_DOWNLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip" \
             | jq -r '.artifacts
-              | if length > 0 then .[0].id else empty end')
-          echo "Last artifact id: ${LAST_ARTIFACT_ID}"
-          curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
+              | if length > 0 then .[0].archive_download_url else empty end')
+          echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
+          curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
 
       - name: unzip carryover
         id: unzip-carryover

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -75,15 +75,12 @@ jobs:
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
-          if [ -z "${ARCHIVE_DOWNLOAD_URL+x}" ]; then
-            echo "Variable is unset."
-          elif [ -z "$ARCHIVE_DOWNLOAD_URL" ]; then
-            echo "Variable is set but empty."
+          if [ -z "$ARCHIVE_DOWNLOAD_URL" ]; then
+            echo "Artifact not available to download."
           else
-            echo "Variable has a value: '$my_var'"
+            curl -sS -L -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "${ARCHIVE_DOWNLOAD_URL}"
+            unzip .sbom/carryover.zip -d .sbom
           fi
-          curl -sS -L -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "${ARCHIVE_DOWNLOAD_URL}"
-          unzip .sbom/carryover.zip -d .sbom
           ls -R .sbom
           
       - name: Generate Current SBOM CDX format

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -130,13 +130,9 @@ jobs:
           # CDX version
           echo "" >> .sbom/comparison.md
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "### Comparison of current CDX SBOM with base repository" >> .sbom/comparison.md
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            echo "### Comparison of current CDX SBOM with previous commit" >> .sbom/comparison.md
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "### Comparison of current CDX SBOM with base repo" >> .sbom/comparison.md
+            echo "### Comparison to base repository" >> .sbom/comparison.md
           else
-            echo "### Comparison not completed" >> .sbom/comparison.md
+            echo "### Comparison to previous commit" >> .sbom/comparison.md
           fi
           cat .sbom/comparison.cdx.md >> .sbom/comparison.md # copy differnces to the historic version
 

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -71,8 +71,13 @@ jobs:
             | jq -r '.artifacts
               | if length > 0 then .[0].id else empty end')
           echo "Last artifact id: ${LAST_ARTIFACT_ID}"
-          curl -o .sbom/carryover.zip -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
+
+      - name: unzip carryover
+        id: unzip-carryover
+        run: |
+          ls -R .sbom
           unzip .sbom/carryover.zip -d .sbom
           ls -R .sbom
 

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -13,14 +13,14 @@ name: SBOM compare
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-      - dev
+#    branches:
+#      - main
+#      - dev
 
   pull_request:
-    branches:
-      - main
-      - dev
+#    branches:
+#      - main
+#      - dev
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -18,9 +18,9 @@ on:
       - dev
 
   pull_request:
-#    branches:
-#      - main
-#      - dev
+    branches:
+      - main
+      - dev
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -62,21 +62,17 @@ jobs:
         run: |
           echo "token: ${{ secrets.GITHUB_TOKEN }}"
           LAST_WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}"
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" /
             | jq -r '.workflow_runs
               | if length > 0 then .[0].id else empty end')
           echo "Last successful run workflow id: ${LAST_WORKFLOW_ID}"
           LAST_ARTIFACT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip"
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip" /
             | jq -r '.artifacts
               | if length > 0 then .[0].id else empty end')
           echo "Last artifact id: ${LAST_ARTIFACT_ID}"
-          curl -o .sbom/carryover.zip "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
-
-            | jq -r '.workflow_runs 
-              | map(select(.name == "SBOM compare"))  # Replace "Your Workflow Name" with the desired name
-              | if length > 1 then .[1].id else empty end')  # Fetch the second most recent run with the matching name
-
+          curl -o .sbom/carryover.zip -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
 
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -1,5 +1,5 @@
 # download previous compare history for this branch
-# - continue-on-error whenever this is a first run and no file is available to download
+# - continue-on-error whenever this is a first run for the selected branch BECAUSE there is no history file is available to download
 # create a current SBOM
 # create a previous SBOM from:
 #  - pull_request, use base repository

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -115,6 +115,10 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             PR_NUMBER=$(jq -r '.number' "$GITHUB_EVENT_PATH")
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            echo "pr_number=none (push)" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "pr_number=none (workflow_dispatch)" >> $GITHUB_OUTPUT
           else
             echo "pr_number=none" >> $GITHUB_OUTPUT
           fi
@@ -123,7 +127,7 @@ jobs:
         id: create-summary
         run: |
           TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S %Z")
-          echo "# Pull Request Number: ${{ steps.pr.outputs.pr_number }}"  > .sbom/comparison.md
+          echo "# Pull Request Number: ${{ steps.get-pr-number.outputs.pr_number }}"  > .sbom/comparison.md
           echo "## Run Timestamp: $TIMESTAMP" >> .sbom/comparison.md
           
           # CDX version

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -61,13 +61,12 @@ jobs:
         continue-on-error: true
         run: |
           echo "token: ${{ secrets.GITHUB_TOKEN }}"
-          LAST_WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
             | jq -r '.workflow_runs
-              | if length > 0 then .[0].id else empty end')
-          echo "Last successful run workflow id: ${LAST_WORKFLOW_ID}"
-          ARCHIVE_DOWNLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip" \
+              | if length > 0 then .[0].artifacts_url else empty end')
+          echo "Artifacts URL: ${ARTIFACTS_URL}"
+          ARCHIVE_DOWNLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARTIFACTS_URL}?name=carryover.zip" \
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -83,6 +83,8 @@ jobs:
         id: previous-sbom-cdx
         run: |
           echo "github.event_name = ${{ github.event_name }}"
+          echo "github.base_ref   = ${{ github.base_ref }}"
+          echo "github.head_ref   = ${{ github.head_ref }}"
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             git checkout ${{ github.base_ref }}
             cdxgen -o .sbom/previous.cdx.json --json-pretty

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -92,6 +92,10 @@ jobs:
             git checkout ${{ github.base_ref }}
             cdxgen -o .sbom/previous.cdx.json --json-pretty
             git checkout ${{ github.head_ref }}
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            git checkout ${{ github.base_ref }}
+            cdxgen -o .sbom/previous.cdx.json --json-pretty
+            git checkout ${{ github.head_ref }}
           else
             cp .sbom/current.cdx.json .sbom/previous.cdx.json
           fi

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -70,6 +70,9 @@ jobs:
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
+          # try noauth
+          curl -o .sbom/carryover.zip "${ARCHIVE_DOWNLOAD_URL}"
+          # try auth
           curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
 
       - name: unzip carryover

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -55,23 +55,23 @@ jobs:
       - name: setup artifact folder
         run: mkdir .sbom
 
-      - name: Get Previous Run ID
-        id: get-run-id
+      - name: Download carryover file from last successful run of this branch
+        id: dl-prev-carryover-zip
         # fail expected if no previous github action run exists - allow the script to continue
         continue-on-error: true
         run: |
-          echo "Github token: ${{ secrets.GITHUB_TOKEN }}"
+          echo "token: ${{ secrets.GITHUB_TOKEN }}"
           LAST_WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}"
             | jq -r '.workflow_id
               | if length > 0 then .[0].id else empty end')
-          echo "Last successful run workflow id: ${{ LAST_WORKFLOW_ID }}"
+          echo "Last successful run workflow id: ${LAST_WORKFLOW_ID }"
           LAST_ARTIFACT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${{ LAST_WORKFLOW_ID }}/artifacts?name=carryover.zip" \
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip"
             | jq -r '.id
               | if length > 0 then .[0].id else empty end')
-          echo "Last artifact id: ${{ LAST_WORKFLOW_ID }}"
-          curl -o .sbom/carryover.zip "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${{ LAST_ARTIFACT_ID }}/zip"
+          echo "Last artifact id: ${LAST_WORKFLOW_ID}"
+          curl -o .sbom/carryover.zip "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
 
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -13,9 +13,9 @@ name: SBOM compare
 on:
   workflow_dispatch:
   push:
-#    branches:
-#      - main
-#      - dev
+    branches:
+      - main
+      - dev
 
   pull_request:
 #    branches:

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -83,8 +83,9 @@ jobs:
         id: previous-sbom-cdx
         run: |
           echo "github.event_name = ${{ github.event_name }}"
-          echo "github.base_ref   = ${{ github.base_ref }}"
-          echo "github.head_ref   = ${{ github.head_ref }}"
+          echo "Base and Head variables exist if PR:"
+          echo "  - github.base_ref = ${{ github.base_ref }}"
+          echo "  - github.head_ref = ${{ github.head_ref }}"
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             git checkout ${{ github.base_ref }}
             cdxgen -o .sbom/previous.cdx.json --json-pretty

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -69,7 +69,8 @@ jobs:
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
-          curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
+          #test curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
 
       - name: unzip carryover
         id: unzip-carryover

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -75,6 +75,13 @@ jobs:
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
+          if [ -z "${ARCHIVE_DOWNLOAD_URL+x}" ]; then
+            echo "Variable is unset."
+          elif [ -z "$ARCHIVE_DOWNLOAD_URL" ]; then
+            echo "Variable is set but empty."
+          else
+            echo "Variable has a value: '$my_var'"
+          fi
           curl -sS -L -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "${ARCHIVE_DOWNLOAD_URL}"
           unzip .sbom/carryover.zip -d .sbom
           ls -R .sbom

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -70,8 +70,8 @@ jobs:
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
           #curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
-          curl -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "$ARCHIVE_DOWNLOAD_URL"
-          #wget --header="Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$ARCHIVE_DOWNLOAD_URL" -O .sbom/carryover.zip
+          #curl -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "$ARCHIVE_DOWNLOAD_URL"
+          wget --header="Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$ARCHIVE_DOWNLOAD_URL" -O .sbom/carryover.zip
           
       - name: unzip carryover
         id: unzip-carryover

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -74,7 +74,7 @@ jobs:
             cdxgen -o .sbom/previous.cdx.json --json-pretty
             git checkout ${{ github.head_ref }}
           else
-            copy .sbom/current.cdx.json .sbom/previous.cdx.json
+            cp .sbom/current.cdx.json .sbom/previous.cdx.json
           fi
           echo "previous_sbom=.sbom/previous.cdx.json" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -60,10 +60,17 @@ jobs:
         # fail expected if no previous github action run exists - allow the script to continue
         continue-on-error: true
         run: |
-          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
-            | jq -r '.workflow_runs
-              | if length > 0 then .[0].artifacts_url else empty end')
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.head_ref }}" \
+              | jq -r '.workflow_runs
+                | if length > 0 then .[0].artifacts_url else empty end')
+          else
+            ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
+              | jq -r '.workflow_runs
+                | if length > 0 then .[0].artifacts_url else empty end')
+          fi
           echo "Artifacts URL: ${ARTIFACTS_URL}"
           ARCHIVE_DOWNLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARTIFACTS_URL}?name=carryover.zip" \
             | jq -r '.artifacts

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -60,25 +60,25 @@ jobs:
         # fail expected if no previous github action run exists - allow the script to continue
         continue-on-error: true
         run: |
-          ARTIFACTS_URL=$(curl -s "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
+          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
             | jq -r '.workflow_runs
               | if length > 0 then .[0].artifacts_url else empty end')
           echo "Artifacts URL: ${ARTIFACTS_URL}"
-          ARCHIVE_DOWNLOAD_URL=$(curl -s "${ARTIFACTS_URL}?name=carryover.zip" \
+          ARCHIVE_DOWNLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARTIFACTS_URL}?name=carryover.zip" \
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
-          # try noauth
-          curl -o .sbom/carryover.zip "${ARCHIVE_DOWNLOAD_URL}"
+          curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
 
       - name: unzip carryover
         id: unzip-carryover
         continue-on-error: true
         run: |
-          ls -R .sbom
-          unzip .sbom/carryover.zip -d .sbom
-          ls -R .sbom
-
+          cd .sbom
+          unzip carryover.zip
+          ls -R
+          cd ..
+          
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx
         run: |

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -60,7 +60,8 @@ jobs:
         # fail expected if no previous github action run exists - allow the script to continue
         continue-on-error: true
         run: |
-          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
+          ARTIFACTS_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
             | jq -r '.workflow_runs
               | if length > 0 then .[0].artifacts_url else empty end')
           echo "Artifacts URL: ${ARTIFACTS_URL}"
@@ -75,8 +76,9 @@ jobs:
         continue-on-error: true
         run: |
           cd .sbom
+          cat carryover.zip
           unzip carryover.zip
-          ls -R
+          ls
           cd ..
           
       - name: Generate Current SBOM CDX format

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -70,8 +70,8 @@ jobs:
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
           #curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
-          #curl -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}" "$ARCHIVE_DOWNLOAD_URL"
-          wget --header="Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$ARCHIVE_DOWNLOAD_URL" -O .sbom/carryover.zip
+          curl -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" "$ARCHIVE_DOWNLOAD_URL"
+          #wget --header="Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$ARCHIVE_DOWNLOAD_URL" -O .sbom/carryover.zip
           
       - name: unzip carryover
         id: unzip-carryover

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -73,7 +73,7 @@ jobs:
           echo "Last artifact id: ${LAST_ARTIFACT_ID}"
           curl -o .sbom/carryover.zip -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
-          unzip carryover.zip -d .sbom
+          unzip .sbom/carryover.zip -d .sbom
           ls -R .sbom
 
       - name: Generate Current SBOM CDX format

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -73,6 +73,7 @@ jobs:
           echo "Last artifact id: ${LAST_ARTIFACT_ID}"
           curl -o .sbom/carryover.zip -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/artifacts/${LAST_ARTIFACT_ID}/zip"
+          unzip carryover.zip -d .sbom
           ls -R .sbom
 
       - name: Generate Current SBOM CDX format

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -115,26 +115,20 @@ jobs:
         id: compare-sbom-cdx
         continue-on-error: true
         run: sbomdiff .sbom/previous.cdx.json .sbom/current.cdx.json --sbom cyclonedx --format text > .sbom/comparison.cdx.md
-
-      - name: Get PR number
-        id: get-pr-number
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            PR_NUMBER=$(jq -r '.number' "$GITHUB_EVENT_PATH")
-            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            echo "pr_number=none (push)" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "pr_number=none (workflow_dispatch)" >> $GITHUB_OUTPUT
-          else
-            echo "pr_number=none" >> $GITHUB_OUTPUT
-          fi
        
       - name: create summary
         id: create-summary
         run: |
           TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S %Z")
-          echo "# Pull Request Number: ${{ steps.get-pr-number.outputs.pr_number }}"  > .sbom/comparison.md
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "# Pull Request Number: $(jq -r '.number' "$GITHUB_EVENT_PATH")"  > .sbom/comparison.md
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            echo "# Push Commit"  > .sbom/comparison.md
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "# Workflow Dispatch"  > .sbom/comparison.md
+          else
+            echo "# Type unknown"  > .sbom/comparison.md
+          fi
           echo "## Run Timestamp: $TIMESTAMP" >> .sbom/comparison.md
           
           # CDX version

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -69,9 +69,10 @@ jobs:
             | jq -r '.artifacts
               | if length > 0 then .[0].archive_download_url else empty end')
           echo "Archive download URL: ${ARCHIVE_DOWNLOAD_URL}"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
-          #test curl -o .sbom/carryover.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
-
+          #curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${ARCHIVE_DOWNLOAD_URL}"
+          #curl -o .sbom/carryover.zip -H "Authorization: token ${{secrets.GITHUB_TOKEN}" "$ARCHIVE_DOWNLOAD_URL"
+          wget --header="Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$ARCHIVE_DOWNLOAD_URL" -O .sbom/carryover.zip
+          
       - name: unzip carryover
         id: unzip-carryover
         continue-on-error: true

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -62,12 +62,12 @@ jobs:
         run: |
           echo "token: ${{ secrets.GITHUB_TOKEN }}"
           LAST_WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" /
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/workflows/sbom-compare.yml/runs?status=success&branch=${{ github.ref_name }}" \
             | jq -r '.workflow_runs
               | if length > 0 then .[0].id else empty end')
           echo "Last successful run workflow id: ${LAST_WORKFLOW_ID}"
           LAST_ARTIFACT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip" /
+            "https://api.github.com/repos/ssc-dsai/canchat-v2/actions/runs/${LAST_WORKFLOW_ID}/artifacts?name=carryover.zip" \
             | jq -r '.artifacts
               | if length > 0 then .[0].id else empty end')
           echo "Last artifact id: ${LAST_ARTIFACT_ID}"

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -90,16 +90,10 @@ jobs:
             git checkout ${{ github.base_ref }}
             cdxgen -o .sbom/previous.cdx.json --json-pretty
             git checkout ${{ github.head_ref }}
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            git checkout HEAD^
-            cdxgen -o .sbom/previous.cdx.json --json-pretty
-            git checkout -
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            git checkout HEAD^
-            cdxgen -o .sbom/previous.cdx.json --json-pretty
-            git checkout -
           else
-            cp .sbom/current.cdx.json .sbom/previous.cdx.json
+            git checkout HEAD^
+            cdxgen -o .sbom/previous.cdx.json --json-pretty
+            git checkout -
           fi
           echo "previous_sbom=.sbom/previous.cdx.json" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2  # Fetch the previous commit for comparison
-          ref: ${{ github.head_ref }}  # For PRs, checkout the head branch
+          fetch-depth: 0  # Fetch all previous commits, changed from 2 (last) to 0 (all)
+#          ref: ${{ github.head_ref }}
          
       - name: Install Dependencies
         run: |
@@ -52,46 +52,8 @@ jobs:
           # sbomdiff (create a DIFF from either format SBOM into TXT)
           pip install sbomdiff
 
-          # sbom-sorter
-          git clone https://github.com/arturmartins/spdx-sorter.git
-
       - name: setup artefact folder
         run: mkdir .sbom
-
-      - name: Get Previous Run ID
-        id: get-run-id
-        # fail expected if no previous github action run exists - allow the script to continue
-        continue-on-error: true
-        run: |
-         RUN_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/runs?branch=${{ github.ref_name }}" \
-            | jq -r '.workflow_runs 
-              | map(select(.name == "SBOM compare"))  # Replace "Your Workflow Name" with the desired name
-              | if length > 1 then .[1].id else empty end')  # Fetch the second most recent run with the matching name
-            echo "run_id=${RUN_ID:-}" >> $GITHUB_OUTPUT
-
-      - name: Download carryover files from last run
-        uses: actions/download-artifact@v8
-        # fail expected if no previous github action run exists or doesnt have carryover artifact - allow the script to continue
-        continue-on-error: true
-        with:
-          path: .sbom
-          name: carryover.zip
-          merge-multiple: true
-          run-id: ${{ steps.get-run-id.outputs.run_id }}
-          github-token:  ${{ secrets.GITHUB_TOKEN}} # may need a custom token ie: MY_PAT_TOKEN
-
-      - name: show downloaded artifacts in run log
-        run: ls -R .sbom    # gut check
-
-      - name: Create SPDX SBOM files
-        # SPDX previous is created by copying the SPDX current from the previous execution - if exists
-        id: current-sbom-spdx
-        run: |
-          # copy current to previous then download new SBOM as current
-          if test -f .sbom/current.spdx.json; then cp .sbom/current.spdx.json .sbom/previous.spdx.json; fi
-          curl https://github.com/ssc-dsai/canchat-v2/dependency-graph/sbom | jq > .sbom/current.spdx.json
-          python spdx-sorter/sort_spdx.py .sbom/current.spdx.json
 
       - name: Generate Current SBOM CDX format
         id: current-sbom-cdx
@@ -102,36 +64,28 @@ jobs:
       - name: Generate Previous SBOM CDX format
         id: previous-sbom-cdx
         run: |
-          git checkout HEAD^
-          cdxgen -o .sbom/previous.cdx.json --json-pretty
+          echo "github.event_name = ${{ github.event_name }}"
+          if [ "${{ github.event_name }}" == "push" ]; then
+            git checkout HEAD^
+            cdxgen -o .sbom/previous.cdx.json --json-pretty
+            git checkout -
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then-
+            git checkout ${{ github.base_ref }}
+            cdxgen -o .sbom/previous.cdx.json --json-pretty
+            git checkout ${{ github.head_ref }}
+          else
+            copy .sbom/current.cdx.json .sbom/previous.cdx.json
+          fi
           echo "previous_sbom=.sbom/previous.cdx.json" >> $GITHUB_OUTPUT
-          git checkout -
 
       - name: Create CSVs
         id: convert-sboms
-        run: |
-          ./cyclonedx convert --input-file .sbom/current.cdx.json --output-file .sbom/current.cdx.csv
-          ./cyclonedx convert --input-file .sbom/current.spdx.json --output-file .sbom/current.spdx.csv
+        run: ./cyclonedx convert --input-file .sbom/current.cdx.json --output-file .sbom/current.cdx.csv
 
       - name: Compare CDX SBOMs
         id: compare-sbom-cdx
         continue-on-error: true
-        run: |
-          if [ -f .sbom/previous.cdx.json ] && [ -f .sbom/current.cdx.json ]; then
-            sbomdiff .sbom/previous.cdx.json .sbom/current.cdx.json --sbom cyclonedx --format text > .sbom/comparison.cdx.md
-          else
-            echo "Unable to compare CDX SBOMs. A previous commit for this branch may not exist." > .sbom/comparison.cdx.md
-          fi
-
-      - name: Compare SPDX SBOMs
-        id: compare-sbom-spdx
-        continue-on-error: true
-        run: |
-          if [ -f .sbom/previous.spdx.json ] && [ -f .sbom/current.spdx.json ]; then
-            sbomdiff .sbom/previous.spdx.json .sbom/current.spdx.json --sbom spdx --format text > .sbom/comparison.spdx.md
-          else
-            echo "Unable to compare SPDX SBOMs. The previous run may have failed to upload a file." > .sbom/comparison.spdx.md
-          fi
+        run: sbomdiff .sbom/previous.cdx.json .sbom/current.cdx.json --sbom cyclonedx --format text > .sbom/comparison.cdx.md
 
       - name: Get PR number
         id: pr
@@ -155,20 +109,6 @@ jobs:
           echo "" >> .sbom/comparison.md
           echo "### Comparison of current CDX SBOM with previous commit" >> .sbom/comparison.md
           cat .sbom/comparison.cdx.md >> .sbom/comparison.md # copy differnces to the historic version
-          
-          # SPDX version
-          echo "" >> .sbom/comparison.md
-          echo "### Comparison of current SPDX SBOM with previous CI run" >> .sbom/comparison.md
-          cat .sbom/comparison.spdx.md >> .sbom/comparison.md # copy differnces to the historic version
-          
-          # prepend current comparison log to the top of the comparison history file (most recent first)
-          echo "" >> .sbom/comparison.md
-          if test -f .sbom/comparison-history.md; then cp .sbom/comparison-history.md .sbom/old-comparison-history.md; fi
-          cp .sbom/comparison.md .sbom/comparison-history.md
-          if test -f .sbom/old-comparison-history.md; then 
-            cat .sbom/old-comparison-history.md >> .sbom/comparison-history.md
-          fi
-          cat .sbom/comparison-history.md >> $GITHUB_STEP_SUMMARY
 
       - name: show artifacts in run log before upload
         run: ls -R .sbom    # gut check
@@ -182,8 +122,6 @@ jobs:
             .sbom/comparison.md
             .sbom/current.cdx.csv
             .sbom/current.cdx.json
-            .sbom/current.spdx.csv
-            .sbom/current.spdx.json
 
       - name: Upload carryover
         uses: actions/upload-artifact@v7
@@ -192,4 +130,3 @@ jobs:
           include-hidden-files: true
           path: |
             .sbom/comparison-history.md
-            .sbom/current.spdx.json

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -69,7 +69,7 @@ jobs:
             git checkout HEAD^
             cdxgen -o .sbom/previous.cdx.json --json-pretty
             git checkout -
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then-
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             git checkout ${{ github.base_ref }}
             cdxgen -o .sbom/previous.cdx.json --json-pretty
             git checkout ${{ github.head_ref }}

--- a/.github/workflows/sbom-compare.yml
+++ b/.github/workflows/sbom-compare.yml
@@ -18,9 +18,9 @@ on:
       - dev
 
   pull_request:
-    branches:
-      - main
-      - dev
+#    branches:
+#      - main
+#      - dev
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'


### PR DESCRIPTION
# Pull Request Checklist

Update to "SBOM-compare" github action (sbom-compare.yaml).

Target: dev

Changes:
- removed SPDX SBOM
- changed CDX SBOM comparison to be aware of PUSH vs PULL REQUEST, and create the correct 'previous' SBOM.
- refactor download:
    - removed the SBOM from the carryover.zip file.
    - removed actions/download-artifact
    - added download via sequential REST API calls
    - removed runtime error when artifact file 'carryover.zip' is available for download (first run, or deleted/expired artifact).
